### PR TITLE
Lame fix

### DIFF
--- a/t/overrides-exit-also.t
+++ b/t/overrides-exit-also.t
@@ -1,0 +1,17 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use Test::More tests => 2;
+
+use Test::Exit;
+
+our $tried_to_exit;
+BEGIN {
+	no warnings 'redefine';
+	*CORE::GLOBAL::exit = sub { $tried_to_exit++ };
+}
+
+exits_ok { exit 1 } "our exit handler is still in place";
+ok( ! $tried_to_exit, "preexisting exit handler not called (dang)" );


### PR DESCRIPTION
Here's a lame patch to allow someone else to override CORE::GLOBAL::exit inside a BEGIN block.

(Just do the work inside an INIT. Lame patch is lame.)
